### PR TITLE
Fix broken internal links in MDX docs under Pages basePath

### DIFF
--- a/apps/site/components/doc-link.component.tsx
+++ b/apps/site/components/doc-link.component.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import type { DocLinkProps } from './doc-link.types';
+
+const EXTERNAL_SCHEME_PATTERN = /^([a-z][a-z\d+\-.]*:|\/\/)/i;
+
+export function DocLink({ href, children, ...rest }: DocLinkProps) {
+  if (!href) {
+    return <a {...rest}>{children}</a>;
+  }
+
+  if (EXTERNAL_SCHEME_PATTERN.test(href)) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" {...rest}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} {...rest}>
+      {children}
+    </Link>
+  );
+}

--- a/apps/site/components/doc-link.types.ts
+++ b/apps/site/components/doc-link.types.ts
@@ -1,0 +1,5 @@
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+
+export type DocLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  children?: ReactNode;
+};

--- a/apps/site/components/mdx-content.component.tsx
+++ b/apps/site/components/mdx-content.component.tsx
@@ -8,6 +8,7 @@ import { ThemeShowcase } from './theme-showcase.component';
 import { MdxTabs } from './mdx-tabs.component';
 import { UsageTabs } from './usage-tabs.component';
 import { CodeBlock } from './code-block.component';
+import { DocLink } from './doc-link.component';
 import { useSiteTheme } from '@/hooks';
 import type {
   CodeGlossTab,
@@ -26,6 +27,7 @@ const MDX_COMPONENTS = {
   MdxTabs,
   UsageTabs,
   pre: CodeBlock,
+  a: DocLink,
 };
 
 function CodeGlossWithTabs(props: CodeGlossProps) {


### PR DESCRIPTION
## Summary
- MDX compiles markdown links like \`[docs](/docs/plugin)\` into raw \`<a>\` tags. Next.js only auto-prefixes \`basePath\` for \`<Link>\`, so the production site (served under \`/codegloss/\`) was emitting absolute \`/docs/*\` hrefs and 404ing across all the cross-doc / \"Next steps\" links (e.g. https://lurx.github.io/codegloss/docs/plugin/).
- Adds a \`DocLink\` component routed via \`MDX_COMPONENTS.a\`:
  - internal hrefs → \`next/link\` (basePath-aware)
  - external schemes (\`http://\`, \`https://\`, \`mailto:\`, \`//\`) → native \`<a target=\"_blank\" rel=\"noopener noreferrer\">\`
  - empty href preserved as-is

No per-doc edits needed — fix applies across every MDX page.

## Test plan
- [ ] \`pnpm -C apps/site dev\` — click \"Remark Plugin\" under \"Next steps\" on the Getting Started page, it resolves
- [ ] Build + deploy to Pages: links under \`/codegloss/docs/\` hit the right pages
- [ ] External links in docs (e.g. velite.js.org in setup/velite) still open in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)