### PR TITLE
ci(publish): use RELEASE_TOKEN so version-packages PR cascades CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
   snapshot:
     name: PR snapshot


### PR DESCRIPTION
## Summary

- Swap `secrets.GITHUB_TOKEN` for `secrets.RELEASE_TOKEN` on the `changesets/action@v1` step in `publish.yml`.

## Why

PR #14 (the bot-opened Version Packages PR) sits with an empty checks tab because GitHub deliberately blocks workflows authenticated with the default `GITHUB_TOKEN` from triggering downstream workflows. Since `github-actions[bot]` pushed the `changeset-release/main` branch using that default token, none of our `pull_request`-triggered workflows (unit / e2e / e2e-site / integration / velite / docusaurus) fire on PR #14.

Swapping in a PAT (`RELEASE_TOKEN`, scopes: `repo` + `workflow`) makes the bot push act on behalf of a real user, which cascades CI normally.

After this merges, the next push to `main` re-runs the Release workflow with the PAT. `changesets/action` will force-push an updated commit onto `changeset-release/main`, which fires `pull_request: synchronize` on PR #14 and runs all required checks.

## Test plan

- [ ] Merge this PR into main
- [ ] Confirm the Release workflow re-runs on main and succeeds
- [ ] Confirm PR #14 gets a new commit from the PAT user
- [ ] Confirm all 6 required checks run and pass on PR #14
- [ ] Merge PR #14 to trigger npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)