### PR TITLE
ci(publish): pass RELEASE_TOKEN to checkout so changeset push cascades CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Persist the PAT into .git/config so the git push that
+          # changesets/action runs (to update changeset-release/main) is
+          # authenticated as a real user, not github-actions[bot]. That's
+          # what lets the resulting pull_request synchronize event cascade
+          # into the required CI workflows on the Version Packages PR.
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary

- Pass `secrets.RELEASE_TOKEN` to the `actions/checkout@v6` step in `publish.yml` so the PAT is persisted into `.git/config` and used for the git push that `changesets/action` runs.

## Why

PR #15 swapped the PAT onto the `changesets/action` step only. That fixed the PR-creation REST call, but the git push that updates `changeset-release/main` still went out with the default `GITHUB_TOKEN` credentials persisted by the checkout step. Result: commit `b1b66e5` on PR #14 is still authored by `github-actions[bot]`, so cascade into the required workflows is still blocked.

Passing the PAT to `actions/checkout` persists it into `.git/config` (default `persist-credentials: true`), so subsequent `git push` commands authenticate as the PAT user. The resulting `pull_request: synchronize` event then triggers the required CI workflows on PR #14.

## Test plan

- [ ] Merge into main
- [ ] Confirm Release workflow re-runs and succeeds
- [ ] Confirm the next force-push on PR #14 is authored by the PAT user (not `github-actions[bot]`)
- [ ] Confirm all 6 required checks run on PR #14
- [ ] Merge PR #14 to trigger npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)