### PR TITLE
ci: snapshot label trigger + sentinel pattern for required checks

### DIFF
--- a/.github/workflows/e2e-site.yml
+++ b/.github/workflows/e2e-site.yml
@@ -1,32 +1,40 @@
 name: E2E site tests
 
+# Sentinel pattern — see unit.yml. Branch protection should require
+# `E2E site tests / required`.
+
 on:
   push:
     branches: [main]
-    paths:
-      - 'packages/codegloss/**'
-      - 'apps/site/**'
-      - 'test/e2e-site/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'package.json'
-      - '.github/workflows/e2e-site.yml'
   pull_request:
-    paths:
-      - 'packages/codegloss/**'
-      - 'apps/site/**'
-      - 'test/e2e-site/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'package.json'
-      - '.github/workflows/e2e-site.yml'
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            run:
+              - 'packages/codegloss/**'
+              - 'apps/site/**'
+              - 'test/e2e-site/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'package.json'
+              - '.github/workflows/e2e-site.yml'
+
   playwright-version:
     name: Resolve Playwright version
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.read.outputs.version }}
@@ -39,7 +47,8 @@ jobs:
 
   e2e-site:
     name: e2e-site / ${{ matrix.browser }}
-    needs: playwright-version
+    needs: [changes, playwright-version]
+    if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v${{ needs.playwright-version.outputs.version }}-noble
@@ -78,3 +87,18 @@ jobs:
           name: playwright-site-traces-${{ matrix.browser }}
           path: test/e2e-site/test-results/
           retention-days: 7
+
+  required:
+    name: required
+    needs: [changes, e2e-site]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert heavy job passed or was correctly skipped
+        env:
+          RESULT: ${{ needs.e2e-site.result }}
+        run: |
+          if [ "$RESULT" = "failure" ] || [ "$RESULT" = "cancelled" ]; then
+            exit 1
+          fi
+          echo "ok: e2e-site result=$RESULT"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,30 +1,40 @@
 name: E2E tests
 
+# Sentinel pattern — see unit.yml for the rationale. Branch protection
+# should require `E2E tests / required` (not the individual matrix
+# browser names), so path-filtered skips don't deadlock PRs.
+
 on:
   push:
     branches: [main]
-    paths:
-      - 'packages/codegloss/**'
-      - 'test/e2e/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'package.json'
-      - '.github/workflows/e2e.yml'
   pull_request:
-    paths:
-      - 'packages/codegloss/**'
-      - 'test/e2e/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'package.json'
-      - '.github/workflows/e2e.yml'
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            run:
+              - 'packages/codegloss/**'
+              - 'test/e2e/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'package.json'
+              - '.github/workflows/e2e.yml'
+
   playwright-version:
     name: Resolve Playwright version
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.read.outputs.version }}
@@ -37,7 +47,8 @@ jobs:
 
   e2e:
     name: e2e / ${{ matrix.browser }}
-    needs: playwright-version
+    needs: [changes, playwright-version]
+    if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v${{ needs.playwright-version.outputs.version }}-noble
@@ -76,3 +87,18 @@ jobs:
           name: playwright-traces-${{ matrix.browser }}
           path: test/e2e/test-results/
           retention-days: 7
+
+  required:
+    name: required
+    needs: [changes, e2e]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert heavy job passed or was correctly skipped
+        env:
+          RESULT: ${{ needs.e2e.result }}
+        run: |
+          if [ "$RESULT" = "failure" ] || [ "$RESULT" = "cancelled" ]; then
+            exit 1
+          fi
+          echo "ok: e2e result=$RESULT"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,30 +1,39 @@
 name: Integration tests
 
+# Sentinel pattern — see unit.yml. Branch protection should require
+# `Integration tests / required` instead of individual example names.
+
 on:
   push:
     branches: [main]
-    paths:
-      - 'packages/codegloss/**'
-      - 'examples/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'package.json'
-      - '.github/workflows/integration.yml'
   pull_request:
-    paths:
-      - 'packages/codegloss/**'
-      - 'examples/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'package.json'
-      - '.github/workflows/integration.yml'
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            run:
+              - 'packages/codegloss/**'
+              - 'examples/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'package.json'
+              - '.github/workflows/integration.yml'
+
   example:
     name: ${{ matrix.example }}
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -62,3 +71,18 @@ jobs:
 
       - name: Run example build + assertions
         run: pnpm --filter @codegloss-examples/${{ matrix.example }} test
+
+  required:
+    name: required
+    needs: [changes, example]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert heavy job passed or was correctly skipped
+        env:
+          RESULT: ${{ needs.example.result }}
+        run: |
+          if [ "$RESULT" = "failure" ] || [ "$RESULT" = "cancelled" ]; then
+            exit 1
+          fi
+          echo "ok: example result=$RESULT"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,19 +4,23 @@ name: Publish
 # config allows only one workflow per package. Each trigger runs exactly
 # one of the two jobs below.
 #
-# - push → main      → Changesets opens/updates a Version Packages PR;
-#                      merging that PR re-triggers this workflow and
-#                      publishes to npm under the default `latest` tag.
-# - workflow_dispatch → publishes every package under a branch-derived
-#                      dist-tag (snapshot), so reviewers can install a PR
-#                      straight from npm without it touching main.
+# - push → main           → Changesets opens/updates a Version Packages PR;
+#                           merging that PR re-triggers this workflow and
+#                           publishes to npm under the default `latest` tag.
+# - PR labeled `snapshot` → publishes every package under a branch-derived
+#                           dist-tag (snapshot), so reviewers can install a
+#                           PR straight from npm without it touching main.
+#                           Trackable on the PR via the label itself.
+# - workflow_dispatch     → manual escape hatch for snapshot publishes on
+#                           refs that aren't tied to an open PR.
 #
 # Auth via npm Trusted Publishing (OIDC); no NPM_TOKEN secret.
-# See PRE-RELEASE.md for the full workflow.
 
 on:
   push:
     branches: [main]
+  pull_request:
+    types: [labeled]
   workflow_dispatch:
     inputs:
       ref:
@@ -74,14 +78,29 @@ jobs:
 
   snapshot:
     name: PR snapshot
-    if: github.event_name == 'workflow_dispatch'
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'snapshot')
     runs-on: ubuntu-latest
-    concurrency: snapshot-${{ inputs.ref }}
+    concurrency: snapshot-${{ github.event.pull_request.head.ref || inputs.ref }}
     steps:
+      - name: Resolve target ref
+        id: resolve
+        env:
+          DISPATCH_REF: ${{ inputs.ref }}
+          PR_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            ref="$DISPATCH_REF"
+          else
+            ref="$PR_REF"
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ steps.resolve.outputs.ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -101,8 +120,10 @@ jobs:
 
       - name: Derive snapshot tag from ref
         id: tag
+        env:
+          REF: ${{ steps.resolve.outputs.ref }}
         run: |
-          t=$(echo "${{ inputs.ref }}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+          t=$(echo "$REF" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
           echo "tag=$t" >> "$GITHUB_OUTPUT"
 
       - name: Version packages as snapshot

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,29 +1,42 @@
 name: Unit tests
 
+# Sentinel pattern: `changes` decides whether the heavy `test` job runs,
+# and `required` always reports a status so branch protection can require
+# it without deadlocking on PRs that don't touch the filtered paths.
+# Wire branch protection to `Unit tests / required`.
+
 on:
   push:
     branches: [main]
-    paths:
-      - 'packages/codegloss/**'
-      - 'apps/site/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'package.json'
-      - '.github/workflows/unit.yml'
   pull_request:
-    paths:
-      - 'packages/codegloss/**'
-      - 'apps/site/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'package.json'
-      - '.github/workflows/unit.yml'
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            run:
+              - 'packages/codegloss/**'
+              - 'packages/shiki/**'
+              - 'apps/site/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'package.json'
+              - '.github/workflows/unit.yml'
+
   test:
+    name: test
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,5 +64,20 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: packages/codegloss/coverage/lcov.info,apps/site/coverage/lcov.info
+          files: packages/codegloss/coverage/lcov.info,packages/shiki/coverage/lcov.info,apps/site/coverage/lcov.info
           fail_ci_if_error: false
+
+  required:
+    name: required
+    needs: [changes, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert heavy job passed or was correctly skipped
+        env:
+          RESULT: ${{ needs.test.result }}
+        run: |
+          if [ "$RESULT" = "failure" ] || [ "$RESULT" = "cancelled" ]; then
+            exit 1
+          fi
+          echo "ok: test result=$RESULT"


### PR DESCRIPTION
## Summary

Two small-but-related CI infra changes:

1. **Snapshot label trigger** (`publish.yml`) — Applying a `snapshot` label to a PR now triggers the existing snapshot publish job. Ref is resolved from the PR head, tag is derived from the branch name. Makes snapshot runs trackable on the PR itself rather than hiding in the Actions tab.

2. **Sentinel pattern on required workflows** — `unit.yml`, `e2e.yml`, `e2e-site.yml`, `integration.yml` now use a `changes` (`dorny/paths-filter`) + `required` (always-reporting) structure. Path filters move off the `pull_request` trigger into `changes`, so PRs that don't touch the filtered paths stop deadlocking on `Expected — Waiting for status` against required checks. See `dev-plans/REQUIRED-CHECKS-DEADLOCK.md` for the design.

## Branch protection migration (manual, post-merge)

Required-checks list needs to swap from the per-job names to the sentinels:

| Remove | Add |
|---|---|
| `test` | `Unit tests / required` |
| `e2e / chromium` | `E2E tests / required` |
| `e2e-site / chromium` | `E2E site tests / required` |
| `docusaurus`, `nextjs-app`, `velite` | `Integration tests / required` |

## Labels

Created the `snapshot` label (`#1f6feb`) in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)