### PR TITLE
fix(publish): use --no-git-checks instead of invalid --no-git-tag-version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -130,4 +130,8 @@ jobs:
         run: pnpm changeset version --snapshot ${{ steps.tag.outputs.tag }}
 
       - name: Publish to npm under the snapshot tag
-        run: pnpm -r publish --no-git-tag-version --tag ${{ steps.tag.outputs.tag }}
+        # --no-git-checks lets pnpm publish from a dirty tree (changeset
+        # version --snapshot has just modified the package.json versions).
+        # Not to be confused with npm's --no-git-tag-version, which is a
+        # different flag for a different command.
+        run: pnpm -r publish --no-git-checks --tag ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
## Summary

- One-line fix: swap `--no-git-tag-version` (an `npm version` flag) for `--no-git-checks` (the actual pnpm publish option) in the snapshot job.

## Why

Snapshot publishes have been failing at the final publish step with:

\`\`\`
ERROR  Unknown option: 'git-tag-version'
\`\`\`

pnpm doesn't accept `--no-git-tag-version`. The correct pnpm flag to allow publishing from a dirty tree — which `changeset version --snapshot` always produces by bumping the package.json versions — is `--no-git-checks`. Comment added so the distinction doesn't get re-introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)