### PR TITLE
ci: rename sentinel jobs so branch protection matches the actual check names

### DIFF
--- a/.github/workflows/e2e-site.yml
+++ b/.github/workflows/e2e-site.yml
@@ -1,7 +1,7 @@
 name: E2E site tests
 
 # Sentinel pattern — see unit.yml. Branch protection should require
-# `E2E site tests / required`.
+# `e2e-site-required`.
 
 on:
   push:
@@ -88,8 +88,8 @@ jobs:
           path: test/e2e-site/test-results/
           retention-days: 7
 
-  required:
-    name: required
+  e2e-site-required:
+    name: e2e-site-required
     needs: [changes, e2e-site]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,8 +1,8 @@
 name: E2E tests
 
 # Sentinel pattern — see unit.yml for the rationale. Branch protection
-# should require `E2E tests / required` (not the individual matrix
-# browser names), so path-filtered skips don't deadlock PRs.
+# should require `e2e-required` (not the individual matrix browser
+# names), so path-filtered skips don't deadlock PRs.
 
 on:
   push:
@@ -88,8 +88,8 @@ jobs:
           path: test/e2e/test-results/
           retention-days: 7
 
-  required:
-    name: required
+  e2e-required:
+    name: e2e-required
     needs: [changes, e2e]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,7 +1,7 @@
 name: Integration tests
 
 # Sentinel pattern — see unit.yml. Branch protection should require
-# `Integration tests / required` instead of individual example names.
+# `integration-required` instead of individual example names.
 
 on:
   push:
@@ -72,8 +72,8 @@ jobs:
       - name: Run example build + assertions
         run: pnpm --filter @codegloss-examples/${{ matrix.example }} test
 
-  required:
-    name: required
+  integration-required:
+    name: integration-required
     needs: [changes, example]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,9 +1,9 @@
 name: Unit tests
 
 # Sentinel pattern: `changes` decides whether the heavy `test` job runs,
-# and `required` always reports a status so branch protection can require
-# it without deadlocking on PRs that don't touch the filtered paths.
-# Wire branch protection to `Unit tests / required`.
+# and `unit-required` always reports a status so branch protection can
+# require it without deadlocking on PRs that don't touch the filtered
+# paths. Wire branch protection to `unit-required`.
 
 on:
   push:
@@ -67,8 +67,11 @@ jobs:
           files: packages/codegloss/coverage/lcov.info,packages/shiki/coverage/lcov.info,apps/site/coverage/lcov.info
           fail_ci_if_error: false
 
-  required:
-    name: required
+  # Sentinel job names are unique across workflows because branch
+  # protection matches against the literal check_run name, not the
+  # workflow-prefixed display label the GitHub UI shows.
+  unit-required:
+    name: unit-required
     needs: [changes, test]
     if: always()
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Rename each workflow's `required` sentinel job to a unique name:

| Workflow | New job name |
|---|---|
| Unit tests | \`unit-required\` |
| E2E tests | \`e2e-required\` |
| E2E site tests | \`e2e-site-required\` |
| Integration tests | \`integration-required\` |

## Why

Branch protection matches required checks against the literal `check_run.name`, not the workflow-prefixed display label the GitHub UI shows. With four workflows all naming their sentinel job `required`, the four incoming check_runs collide on the same short name, and none of the contexts currently stored in the ruleset (`Unit tests / required`, `E2E tests / required`, etc.) actually match. PRs sit waiting on Required checks that never resolve, even though all four sentinels have completed successfully.

Unique names per workflow let the ruleset point at each sentinel unambiguously.

## Branch protection update (manual, post-merge)

Swap each context in the `main protection` ruleset:

| Remove | Add |
|---|---|
| `Unit tests / required` | `unit-required` |
| `E2E tests / required` | `e2e-required` |
| `E2E site tests / required` | `e2e-site-required` |
| `Integration tests / required` | `integration-required` |

Source can stay pinned to GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)