### PR TITLE
ci: bump Node 20 actions to Node 24 majors

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Setup Node
       uses: actions/setup-node@v6

--- a/.github/workflows/e2e-site.yml
+++ b/.github/workflows/e2e-site.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload traces on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-site-traces-${{ matrix.browser }}
           path: test/e2e-site/test-results/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload traces on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-traces-${{ matrix.browser }}
           path: test/e2e/test-results/

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -90,7 +90,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload coverage artifact for Sonar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: |
@@ -115,7 +115,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage
           # Preserves the packages/*/coverage/lcov.info tree the artifact


### PR DESCRIPTION
## Summary

Bumps the three actions still running on Node.js 20 — they'll be force-migrated by GitHub on 2026-06-02 and removed on 2026-09-16, so doing it now while the upgrade path is quiet.

| Action | Before | After | Why this version |
|---|---|---|---|
| `pnpm/action-setup` | `@v4` | `@v6` | v5 is the Node 24 cut, v6 adds pnpm 11 support without breaking pnpm 10 |
| `actions/upload-artifact` | `@v4` | `@v7` | v6 is the Node 24 default, v7 adds an opt-in `archive: false` param we don't use |
| `actions/download-artifact` | `@v4` | `@v8` | v7 is the Node 24 default, v8's hash-mismatch-as-error is a security upgrade |

The breaking change in `download-artifact@v5` (single-artifact-by-ID path behavior) doesn't affect us — we download by `name`, not `id`.

## Test plan

- [ ] Unit workflow: `upload-artifact` → coverage artifact → `download-artifact` (sonar) round-trip
- [ ] E2E + E2E-site workflows: trace upload on failure (only triggered on a failing test, but the action loads either way)
- [ ] Composite setup: `pnpm install` step still runs across unit, integration, e2e, e2e-site, deploy, publish
- [ ] No more "Node.js 20 actions are deprecated" warnings in run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)