### PR TITLE
ci: scope per-job permissions across remaining workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,8 @@ on:
       - '.github/actions/setup/**'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+# Permissions are scoped per job (S8233/S8264): the build job only
+# needs to checkout + enable Pages, the deploy job needs OIDC + pages.
 
 concurrency:
   group: pages
@@ -25,6 +23,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      pages: write # configure-pages with enablement: true creates the Pages site
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -52,6 +53,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write # deploy-pages
+      id-token: write # OIDC for the Pages deployment attestation
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/e2e-site.yml
+++ b/.github/workflows/e2e-site.yml
@@ -8,8 +8,8 @@ on:
     branches: [main]
   pull_request:
 
-permissions:
-  contents: read
+# Permissions are scoped per job (S8264): the sentinel doesn't need
+# any, and the others only need `contents: read` to checkout.
 
 concurrency:
   group: e2e-site-${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +18,8 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       run: ${{ steps.filter.outputs.run }}
     steps:
@@ -41,6 +43,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.read.outputs.version }}
     steps:
@@ -55,6 +59,8 @@ jobs:
     needs: [changes, playwright-version]
     if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     container:
       image: mcr.microsoft.com/playwright:v${{ needs.playwright-version.outputs.version }}-noble
     env:
@@ -86,6 +92,7 @@ jobs:
     needs: [changes, e2e-site]
     if: always()
     runs-on: ubuntu-latest
+    permissions: {} # sentinel only inspects upstream job results; no checkout
     steps:
       - name: Assert heavy job passed or was correctly skipped
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,8 +9,8 @@ on:
     branches: [main]
   pull_request:
 
-permissions:
-  contents: read
+# Permissions are scoped per job (S8264): the sentinel doesn't need
+# any, and the others only need `contents: read` to checkout.
 
 concurrency:
   group: e2e-${{ github.workflow }}-${{ github.ref }}
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       run: ${{ steps.filter.outputs.run }}
     steps:
@@ -41,6 +43,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.read.outputs.version }}
     steps:
@@ -55,6 +59,8 @@ jobs:
     needs: [changes, playwright-version]
     if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     container:
       image: mcr.microsoft.com/playwright:v${{ needs.playwright-version.outputs.version }}-noble
     env:
@@ -86,6 +92,7 @@ jobs:
     needs: [changes, e2e]
     if: always()
     runs-on: ubuntu-latest
+    permissions: {} # sentinel only inspects upstream job results; no checkout
     steps:
       - name: Assert heavy job passed or was correctly skipped
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,8 +8,8 @@ on:
     branches: [main]
   pull_request:
 
-permissions:
-  contents: read
+# Permissions are scoped per job (S8264): the sentinel doesn't need
+# any, and the others only need `contents: read` to checkout.
 
 concurrency:
   group: integration-${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +18,8 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       run: ${{ steps.filter.outputs.run }}
     steps:
@@ -40,6 +42,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -70,6 +74,7 @@ jobs:
     needs: [changes, example]
     if: always()
     runs-on: ubuntu-latest
+    permissions: {} # sentinel only inspects upstream job results; no checkout
     steps:
       - name: Assert heavy job passed or was correctly skipped
         env:


### PR DESCRIPTION
## Summary

Finishes the per-job permissions refactor started in #22. Every workflow now sets `GITHUB_TOKEN` scopes at the job level instead of the workflow level — Sonar S8264 (read) and S8233 (write).

| Workflow | Before (workflow-level) | After (per-job) |
|---|---|---|
| `deploy.yml` | `contents:read`, `pages:write`, `id-token:write` for everyone | `build`: `contents:read` + `pages:write` · `deploy`: `pages:write` + `id-token:write` |
| `e2e.yml` | `contents:read` for everyone | `contents:read` on the 3 jobs that checkout · `e2e-required` sentinel = `{}` |
| `e2e-site.yml` | same | same shape |
| `integration.yml` | same | `contents:read` on `changes` + `example` · `integration-required` = `{}` |

## Test plan

- [ ] Unit, integration, e2e, e2e-site all green on this PR
- [ ] Deploy workflow doesn't run on PRs (only `push` to main + `workflow_dispatch`); will be exercised on first main push after merge
- [ ] No new Sonar S8233/S8264 warnings on the workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)