### PR TITLE
fix(publish): use Node 24 so OIDC trusted publishing actually exchanges a token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,6 +70,11 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
+          # Node 24 ships with npm >= 11.5, which is the first npm-cli
+          # version that actually performs the OIDC token exchange for
+          # trusted publishing. Node 22's bundled npm 10.x sends an empty
+          # auth header and gets a misleading 404 from the registry.
+          node-version: '24'
           registry-url: https://registry.npmjs.org
 
       - name: Create release PR or publish
@@ -171,6 +176,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
+          # See node-version note on the release job — npm 11.5+
+          # (Node 24) is required for OIDC trusted publishing.
+          node-version: '24'
           registry-url: https://registry.npmjs.org
 
       - name: Derive snapshot tag from ref


### PR DESCRIPTION
## Summary

After #26 wired up env-scoped OIDC trusted publishing, snapshot publishes from PR #17 still failed with the same 404:

\`\`\`
npm error 404 Not Found - PUT https://registry.npmjs.org/codegloss
\`\`\`

Everything _looked_ wired up — the npm trusted publisher entry was correctly configured, the \`npm-publishing\` GitHub environment existed, the job's OIDC \`sub\` claim was correctly scoped to \`environment:npm-publishing\` — yet the registry kept rejecting.

Real cause: the runner is on **Node 22.22.2**, which ships with **npm 10.x**. npm CLI only added OIDC trusted publishing support in **v11.5.1**. With npm 10, the publish step never performs the OIDC token exchange at all — it sends an empty auth header (because \`NODE_AUTH_TOKEN\` is unset by design when using trusted publishing) and the registry answers the unauthenticated PUT with a 404 (npm uses 404 instead of 401 for security).

Pinning **release** and **snapshot** jobs to **Node 24** (npm 11.5+) lets npm-cli actually present the OIDC token to the registry. \`smoke-test\` stays on Node 22 — that job exists specifically to verify published packages work on the engines.node floor (\`>=20\`).

## Why this changed scope

This PR's branch name (\`chore/action-yml-schema-hint\`) reflects its original purpose — a one-line schema-comment fix for an IDE warning on \`action.yml\`. That cosmetic change has been dropped from this branch and the work was re-pointed at this real production fix. The schema hint can come back as a separate PR if desired.

## Test plan

- [ ] Merge this PR
- [ ] Re-fire the snapshot label on PR #17 (or rebase #17 on the new main and force-push)
- [ ] Confirm the snapshot publishes successfully under tag \`fix-rehype-subroot\` with provenance attestation visible at \`https://registry.npmjs.org/-/npm/v1/attestations/codegloss@<snapshot-version>\`
- [ ] Next merge to main with a real changeset publishes \`latest\` with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)