### PR TITLE
ci(publish): refresh PR snapshot on every push to a labeled PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,10 +7,13 @@ name: Publish
 # - push → main           → Changesets opens/updates a Version Packages PR;
 #                           merging that PR re-triggers this workflow and
 #                           publishes to npm under the default `latest` tag.
-# - PR labeled `snapshot` → publishes every package under a branch-derived
-#                           dist-tag (snapshot), so reviewers can install a
-#                           PR straight from npm without it touching main.
-#                           Trackable on the PR via the label itself.
+# - PR with `snapshot` label → publishes every package under a branch-
+#                           derived dist-tag (snapshot), so reviewers can
+#                           install a PR straight from npm without it
+#                           touching main. Triggered both when the label
+#                           is first applied AND on every subsequent push
+#                           to the labeled PR (synchronize), so a rebase
+#                           or fixup automatically refreshes the snapshot.
 # - workflow_dispatch     → manual escape hatch for snapshot publishes on
 #                           refs that aren't tied to an open PR.
 #
@@ -22,7 +25,9 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [labeled]
+    # `synchronize` so a force-push or new commit to a labeled PR refreshes
+    # the snapshot without the reviewer having to re-toggle the label.
+    types: [labeled, synchronize]
   workflow_dispatch:
     inputs:
       ref:
@@ -111,11 +116,21 @@ jobs:
 
   snapshot:
     name: PR snapshot
+    # `contains(...labels.*.name, 'snapshot')` works for both `labeled`
+    # (the just-added label is included in the labels array) and
+    # `synchronize` (no `event.label`, but the PR's current label set is
+    # still on `event.pull_request.labels`). On unlabeled PRs the job is
+    # skipped at the if-gate, so synchronize doesn't publish for everyone.
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'snapshot')
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'snapshot'))
     runs-on: ubuntu-latest
-    concurrency: snapshot-${{ github.event.pull_request.head.ref || inputs.ref }}
+    concurrency:
+      group: snapshot-${{ github.event.pull_request.head.ref || inputs.ref }}
+      # A rapid burst of pushes shouldn't queue up redundant publishes —
+      # only the latest commit should land on the snapshot tag.
+      cancel-in-progress: true
     permissions:
       contents: read # checkout
       id-token: write # OIDC exchange with npm for trusted publishing + provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,11 @@ jobs:
     name: Release (main)
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    # Same environment as `snapshot` so a single npm trusted-publisher
+    # entry (workflow: publish.yml, environment: npm-publishing) covers
+    # both flows. npm only allows one trusted publisher per package, so
+    # we can't split release vs snapshot into separate publisher entries.
+    environment: npm-publishing
     concurrency: release-${{ github.ref }}
     permissions:
       contents: write # changesets/action opens/updates the Version Packages PR
@@ -126,6 +131,16 @@ jobs:
       (github.event_name == 'pull_request' &&
        contains(github.event.pull_request.labels.*.name, 'snapshot'))
     runs-on: ubuntu-latest
+    # Same environment as the release job — npm only allows one
+    # trusted publisher per package, and PR-event OIDC tokens aren't
+    # accepted unless the publish is scoped to an environment that
+    # the trusted publisher specifies. Scoping both jobs to
+    # `npm-publishing` means a single trusted-publisher entry
+    # (workflow: publish.yml, environment: npm-publishing) authorizes
+    # both. Tighten with deployment-branch rules or required reviewers
+    # in repo Settings if you want to gate which PRs can publish
+    # snapshots.
+    environment: npm-publishing
     concurrency:
       group: snapshot-${{ github.event.pull_request.head.ref || inputs.ref }}
       # A rapid burst of pushes shouldn't queue up redundant publishes —


### PR DESCRIPTION
## Summary

The snapshot job was failing for two distinct reasons; this PR fixes both.

### 1. Stale-snapshot reactivity

Triggers were limited to \`pull_request.labeled\`, so once the \`snapshot\` label was on a PR, force-pushes or new commits wouldn't refresh the published snapshot — you'd have to remove and re-apply the label.

| Change | Why |
|---|---|
| \`on.pull_request.types\`: add \`synchronize\` | Fire the workflow on every push to a PR (so labeled ones get rebuilt) |
| \`snapshot.if\`: \`contains(event.pull_request.labels.*.name, 'snapshot')\` | Works on both \`labeled\` and \`synchronize\` events. Unlabeled PRs are still skipped at the if-gate |
| \`snapshot.concurrency.cancel-in-progress: true\` | A rapid burst of pushes only publishes the latest commit |

### 2. Trusted-publishing 404 from PR events

Even with the label re-applied manually, the snapshot publish was getting:

\`\`\`
npm error 404 Not Found - PUT https://registry.npmjs.org/codegloss - Not found
npm error 404  'codegloss@0.0.0-fix-rehype-subroot-...' is not in this registry.
\`\`\`

Root cause: **npm trusted publishers do not accept OIDC tokens issued from \`pull_request\` events** — PRs can come from forks, so the tokens are treated as untrusted. The release job (push to main) works fine; PR-event publishes are blocked at npm's auth layer regardless of what the trusted-publisher entry says.

Fix: scope **both** jobs to a GitHub environment (\`npm-publishing\`). That changes the OIDC subject claim from \`repo:OWNER/REPO:pull_request\` to \`repo:OWNER/REPO:environment:npm-publishing\`, which the trusted-publisher entry is set to accept.

npm only allows one trusted publisher per package, so release and snapshot share the same environment instead of having separate publisher entries.

### Setup already done on the npm + GitHub side (out of band of this PR)

- GitHub environment \`npm-publishing\` created in repo Settings → Environments
- Each of the 5 packages (\`codegloss\`, \`@codegloss/react\`, \`@codegloss/vue\`, \`@codegloss/svelte\`, \`@codegloss/shiki\`) had its existing trusted publisher entry edited to set Environment name = \`npm-publishing\`

### Recommended GitHub-side hardening (optional, not in this PR)

In repo Settings → Environments → \`npm-publishing\`:

- **Required reviewers** — manual approval before each publish (most secure; would also gate releases from main)
- **Deployment branch rules** — restrict to specific branch patterns
- Without either, anyone with write access who can apply the \`snapshot\` label can trigger a snapshot publish

## Test plan

- [ ] After merge, force-push to a PR with the \`snapshot\` label refreshes the snapshot tag without re-toggling the label
- [ ] Unlabeled PRs do not invoke the snapshot job (visible as a "skipped" job, not a failure)
- [ ] Release job from main still publishes \`latest\` with provenance, now via the \`npm-publishing\` environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)