### PR TITLE
ci(publish): retry transient tag-push 5xx after successful npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,6 +79,15 @@ jobs:
 
       - name: Create release PR or publish
         id: changesets
+        # `pnpm changeset publish` is atomic per-package via npm's
+        # Trusted Publishing — once it returns, the package is on the
+        # registry with its provenance attestation. The action then loops
+        # over the new versions and does `git push origin <tag>` one tag
+        # at a time. A transient GitHub 5xx on any one push fails the
+        # action with exit 1, even though the publish itself is consistent.
+        # We swallow that here and let the `Reconcile release outcome`
+        # step below decide whether the job actually failed.
+        continue-on-error: true
         uses: changesets/action@v1
         with:
           version: pnpm changeset version
@@ -88,6 +97,70 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
+
+      - name: Reconcile release outcome
+        # Three cases the previous step can land in:
+        #   1. success                              → nothing to do.
+        #   2. failure, published == 'true'         → publish completed, a
+        #      tag-push hit a 5xx. Retry the missing tag pushes with
+        #      backoff. The job succeeds iff every tag eventually lands.
+        #   3. failure, published != 'true'         → the action broke
+        #      somewhere before publish. That's a real failure; surface it.
+        if: always()
+        env:
+          OUTCOME: ${{ steps.changesets.outcome }}
+          PUBLISHED: ${{ steps.changesets.outputs.published }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "$OUTCOME" = "success" ]; then
+            echo "changesets/action succeeded; nothing to reconcile."
+            exit 0
+          fi
+
+          if [ "$PUBLISHED" != "true" ]; then
+            echo "::error::changesets/action failed before any package was published."
+            exit 1
+          fi
+
+          echo "Publish completed but the action exited with a failure"
+          echo "(likely a transient git-push 5xx). Verifying each package's"
+          echo "tag on origin and re-pushing any missing ones with backoff."
+          echo
+
+          missing=0
+          while read -r tag; do
+            [ -z "$tag" ] && continue
+            if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+              echo "  ok: $tag already on origin"
+              continue
+            fi
+            if ! git rev-parse --verify "refs/tags/$tag" >/dev/null 2>&1; then
+              git tag "$tag" HEAD
+            fi
+            pushed=0
+            for attempt in 1 2 3 4 5; do
+              if git push origin "refs/tags/$tag"; then
+                echo "  ok: $tag pushed (attempt $attempt)"
+                pushed=1
+                break
+              fi
+              echo "  attempt $attempt for $tag failed; waiting 10s..."
+              sleep 10
+            done
+            if [ "$pushed" -ne 1 ]; then
+              echo "::error::failed to push tag $tag after 5 attempts"
+              missing=1
+            fi
+          done < <(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | "\(.name)@\(.version)"')
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+          echo
+          echo "All tags reconciled."
 
   smoke-test:
     name: Smoke-test published tarballs


### PR DESCRIPTION
## Summary

- `changesets/action` runs `pnpm changeset publish` (atomic, OIDC-provenanced) and then loops over the new versions doing `git push origin <tag>` one tag at a time. A transient GitHub 5xx on any single tag-push exits the action 1 and turns the workflow red — even though npm publish has already succeeded for every package.
- 1.0.0 hit exactly this: all five packages published cleanly, four of five tags pushed, the fifth (`@codegloss/svelte@1.0.0`) hit an Internal Server Error from GitHub's git frontend on its single attempt. Release was healthy; CI was red.

## Fix

- Mark the `changesets/action` step `continue-on-error: true` so a tag-push 5xx doesn't immediately fail the job.
- Add a `Reconcile release outcome` step that:
  - no-ops on success;
  - fails fast if the action errored before publish completed (`outputs.published != 'true'`);
  - otherwise verifies each published package's tag on origin and re-pushes any missing one with 5 attempts / 10s backoff.

The job ends with whatever the reconcile step decides, so the `smoke-test` downstream gate (`needs.release.outputs.published == 'true'`, implicit `needs.release.result == 'success'`) only runs when the release is truly green — including the tags.

## Test plan

- [ ] CI on this PR passes (no behavior change for the PR-open path; this only affects the publish-on-main path)
- [ ] After merge, the next real release publishes and either:
  - completes cleanly with no tag flakes, or
  - hits a flake and the reconcile step retries the missing tag(s); workflow ends green
- [ ] If `changesets/action` ever fails for a non-tag-push reason (e.g., the publish itself), `published` stays `'false'` and the reconcile step surfaces the failure — workflow ends red, as it should